### PR TITLE
Mark start function as unsafe

### DIFF
--- a/src/thread/mod.rs
+++ b/src/thread/mod.rs
@@ -17,8 +17,7 @@ pub use self::thread::*;
 /// CreateThread from DllMain and calls FreeLibraryAndExitThread when the function returns.
 ///
 /// The purpose of this function is to aid injected DLLs to start a new thread from inside DllMain's DLL_PROCESS_ATTACH event and free themselves when exited.
-pub fn start(f: fn()) {
-	unsafe {
+pub unsafe fn start(f: fn()) {
 		use std::{mem, ptr};
 		use crate::winapi::*;
 		extern "system" fn thunk(f: LPVOID) -> DWORD {
@@ -29,5 +28,4 @@ pub fn start(f: fn()) {
 			return 0;
 		}
 		CreateThread(ptr::null_mut(), 0, Some(thunk), f as LPVOID, 0, ptr::null_mut());
-	}
 }


### PR DESCRIPTION
https://github.com/CasualX/external/blob/3b4d8fab6174ec1f8aa8df46ad395070eee04651/src/thread/mod.rs#L20-L33
It is not a good choice to mark the entire function body as unsafe, which will make the caller ignore the safety requirements that the function parameters must guarantee, the developer who calls the start function may not notice this safety requirement.
Marking them unsafe also means that callers must make sure they know what they're doing.